### PR TITLE
adds an option to send messages to an alternative topic via IVORefreshSender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 1.22 (current master)
 * enhanced support to get versioned element from MongoDB DAOs
+* adds an option to send messages to an alternative topic via IVORefreshSender
 
 # Version 1.21
 * Interconnect improvements

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/IVORefreshSender.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/IVORefreshSender.java
@@ -28,7 +28,12 @@ import org.apache.activemq.pool.PooledConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.*;
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.Topic;
 import java.io.Serializable;
 
 public class IVORefreshSender {


### PR DESCRIPTION
Adds the option to send the ivo refresh messages to an alternate topic not specified by "interconnect.jms.updatetopic".  

Default behaviour is not changed by this commit.