### PR TITLE
fixes the event id desirialization bug

### DIFF
--- a/interconnect/interconnect-maven-plugin/src/main/resources/event/event.vm
+++ b/interconnect/interconnect-maven-plugin/src/main/resources/event/event.vm
@@ -109,9 +109,7 @@ public class $model.getClazzName() extends $model.getParentClazzName() implement
 #end
 
 	protected $model.getClazzName()(Abstract${model.getClazzName()}Builder<?> builder) {
-#if ( $model.hasParentClazz() )
 		super(builder);
-#end
 #foreach ( $field in $model.getAllFields() )
 		this.$field.name = builder.$field.name;
 #end

--- a/interconnect/model/src/main/java/de/taimos/dvalin/interconnect/model/event/AbstractEvent.java
+++ b/interconnect/model/src/main/java/de/taimos/dvalin/interconnect/model/event/AbstractEvent.java
@@ -32,9 +32,14 @@ public abstract class AbstractEvent implements IEvent {
 
     private static final long serialVersionUID = 1L;
 
-    private UUID eventId = UUID.randomUUID();
-    private DateTime creationDate = DateTime.now();
+    private UUID eventId;
+    private DateTime creationDate;
 
+
+    protected AbstractEvent(AbstractEventBuilder<?> builder) {
+        this.eventId = builder.getEventId();
+        this.creationDate = builder.getCreationDate();
+    }
 
     @Override
     public UUID getEventId() {


### PR DESCRIPTION
The interconnect event module has a bug on deserialization of events:
When mapping from json to event, the eventId currently gets re-generated, which should not be the case.

This commit fixes the issue.