### PR TITLE
23733 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 **/target
 **/.idea/workspace.xml
 **/.idea/tasks.xml
+/.idea/
 .idea/libraries
 .idea/sonarlint
+.idea/misc.xml
+**/*.iml

--- a/interconnect/model/src/test/java/de/taimos/dvalin/interconnect/model/common/daemon/DaemonScannerTest.java
+++ b/interconnect/model/src/test/java/de/taimos/dvalin/interconnect/model/common/daemon/DaemonScannerTest.java
@@ -20,17 +20,6 @@ package de.taimos.dvalin.interconnect.model.common.daemon;
  * #L%
  */
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import de.taimos.dvalin.interconnect.model.InterconnectList;
 import de.taimos.dvalin.interconnect.model.InterconnectObject;
 import de.taimos.dvalin.interconnect.model.ivo.IVO;
@@ -42,6 +31,17 @@ import de.taimos.dvalin.interconnect.model.service.DaemonRequestMethod;
 import de.taimos.dvalin.interconnect.model.service.DaemonScanner;
 import de.taimos.dvalin.interconnect.model.service.IDaemon;
 import de.taimos.dvalin.interconnect.model.service.IDaemonHandler;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.omg.CORBA.SystemException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @SuppressWarnings({"javadoc", "unused"})
 public class DaemonScannerTest {
@@ -59,11 +59,21 @@ public class DaemonScannerTest {
         void testVoid(final VoidIVO ivo);
 	}
 
+    public interface ITestWrongMultiExceptionTypes extends IDaemon, IDaemonHandler {
+
+        @DaemonRequestMethod(idempotent = false)
+        void testVoid(final VoidIVO ivo) throws DaemonError, SystemException;
+    }
 
 	@Test(expected = IllegalStateException.class)
-	public void testMisingExceptionInInterface() {
+	public void testMissingExceptionInInterface() {
 		DaemonScanner.scan(ITestMissingException.class);
 	}
+
+    @Test(expected = IllegalStateException.class)
+    public void testWrongExceptionInInterface() {
+        DaemonScanner.scan(ITestWrongMultiExceptionTypes.class);
+    }
 
 	@Test
 	public void testMisingExceptionInImplementingClass() {


### PR DESCRIPTION
Currently a method on an IDaemon interface may only declare a DaemonError as an exception.

This leads to the following construct in calling methods, if you want to be able to catch a timeout when using ADaemonProxyFactory:
```
catch (UndeclaredThrowableException e) {
	if (e.getUndeclaredThrowable() instanceof TimeoutException) {
		// do something on Timeouts
	} else {
		do something on other errors
	}
```

The commit enables the possible use of "throws de.taimos.dvalin.interconnect.core.exceptions.TimeoutException" on any method on interfaces extending IDaemon, and therefore allowing better exception handling in case of timeouts, if the developer wants to enforce it.

This change is backwards compatible and does not change the behaviour of existing implementations.