### PR TITLE
Adds support for multiple @RequestHandler

### DIFF
--- a/interconnect/core/dvalin-interconnect-core.iml
+++ b/interconnect/core/dvalin-interconnect-core.iml
@@ -3,9 +3,7 @@
   <component name="FacetManager">
     <facet type="Spring" name="Spring">
       <configuration>
-        <fileset id="fileset" name="Spring Application Context" removed="false">
-          <file>file://$MODULE_DIR$/src/main/resources/spring/messaging.xml</file>
-        </fileset>
+        <fileset id="fileset" name="Spring Application Context" removed="false" />
         <fileset id="fileset2" name="Spring Application Context (2)" removed="false">
           <file>file://$MODULE_DIR$/src/main/java/de/taimos/dvalin/interconnect/core/config/JMSConfig.java</file>
         </fileset>

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/JMSConfig.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/JMSConfig.java
@@ -23,9 +23,14 @@ package de.taimos.dvalin.interconnect.core.config;
 import de.taimos.dvalin.interconnect.core.daemon.DaemonRequestResponse;
 import de.taimos.dvalin.interconnect.core.daemon.IDaemonRequestResponse;
 import de.taimos.dvalin.interconnect.core.spring.DaemonMessageListener;
+import de.taimos.dvalin.interconnect.core.spring.IDaemonMessageHandlerFactory;
+import de.taimos.dvalin.interconnect.core.spring.IDaemonMessageSender;
+import de.taimos.dvalin.interconnect.core.spring.SingleDaemonMessageHandler;
+import de.taimos.dvalin.interconnect.model.service.ADaemonHandler;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.jms.pool.PooledConnectionFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -94,6 +99,13 @@ public class JMSConfig {
         return new DaemonRequestResponse();
     }
 
+    @Bean
+    public IDaemonMessageHandlerFactory createDaemonMessageHandlerFactory(BeanFactory beanFactory, IDaemonMessageSender messageSender) {
+        return logger -> {
+            final ADaemonHandler rh = (ADaemonHandler) beanFactory.getBean("requestHandler");
+            return new SingleDaemonMessageHandler(logger, rh.getClass(), messageSender, beanFactory);
+        };
+    }
 
     @Bean
     public DefaultMessageListenerContainer jmsListenerContainer(PooledConnectionFactory jmsFactory, DaemonMessageListener messageListener) {

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/MultiRequestHandlerConfig.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/MultiRequestHandlerConfig.java
@@ -15,7 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Copyright 2022 Cinovo AG<br>
+ * Copyright 2022 Taimos GmbH<br>
  * <br>
  *
  * @author psigloch

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/MultiRequestHandlerConfig.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/MultiRequestHandlerConfig.java
@@ -1,0 +1,40 @@
+package de.taimos.dvalin.interconnect.core.config;
+
+import de.taimos.daemon.spring.conditional.OnSystemProperty;
+import de.taimos.dvalin.interconnect.core.spring.IDaemonMessageHandlerFactory;
+import de.taimos.dvalin.interconnect.core.spring.IDaemonMessageSender;
+import de.taimos.dvalin.interconnect.core.spring.MultiDaemonMessageHandler;
+import de.taimos.dvalin.interconnect.core.spring.RequestHandler;
+import de.taimos.dvalin.interconnect.model.service.IDaemonHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Copyright 2022 Cinovo AG<br>
+ * <br>
+ *
+ * @author psigloch
+ */
+@Configuration
+@OnSystemProperty(propertyName = "interconnect.requesthandler.mode", propertyValue = "multi")
+public class MultiRequestHandlerConfig {
+
+    @Bean
+    @Primary
+    public IDaemonMessageHandlerFactory createDaemonMessageHandlerFactory(ApplicationContext applicationContext, IDaemonMessageSender messageSender) {
+        return logger -> {
+            Set<Class<? extends IDaemonHandler>> handlers = new HashSet<>();
+            for (Object o : applicationContext.getBeansWithAnnotation(RequestHandler.class).values()) {
+                if (o instanceof IDaemonHandler) {
+                    handlers.add(((IDaemonHandler) o).getClass());
+                }
+            }
+            return new MultiDaemonMessageHandler(logger, handlers, messageSender, applicationContext.getAutowireCapableBeanFactory());
+        };
+    }
+}

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/ADaemonProxyFactory.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/ADaemonProxyFactory.java
@@ -9,9 +9,9 @@ package de.taimos.dvalin.interconnect.core.daemon;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,13 +19,6 @@ package de.taimos.dvalin.interconnect.core.daemon;
  * limitations under the License.
  * #L%
  */
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import de.taimos.dvalin.interconnect.model.InterconnectContext;
 import de.taimos.dvalin.interconnect.model.InterconnectObject;
@@ -35,6 +28,19 @@ import de.taimos.dvalin.interconnect.model.service.DaemonError;
 import de.taimos.dvalin.interconnect.model.service.DaemonScanner;
 import de.taimos.dvalin.interconnect.model.service.IDaemon;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Copyright 2015 Taimos GmbH<br>
+ * <br>
+ *
+ * @author Thorsten Hoeger
+ */
 public abstract class ADaemonProxyFactory implements IDaemonProxyFactory {
 
     /**

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/DaemonMethodRegistry.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/DaemonMethodRegistry.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Copyright 2022 Cinovo AG<br>
+ *  Copyright 2022 Taimos GmbH<br>
  * <br>
  *
  * @author psigloch

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/DaemonMethodRegistry.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/daemon/DaemonMethodRegistry.java
@@ -1,0 +1,90 @@
+package de.taimos.dvalin.interconnect.core.daemon;
+
+import de.taimos.dvalin.interconnect.model.InterconnectObject;
+import de.taimos.dvalin.interconnect.model.service.DaemonScanner;
+import de.taimos.dvalin.interconnect.model.service.DaemonScanner.DaemonMethod;
+import de.taimos.dvalin.interconnect.model.service.IDaemonHandler;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Copyright 2022 Cinovo AG<br>
+ * <br>
+ *
+ * @author psigloch
+ */
+public class DaemonMethodRegistry {
+
+    private final Map<Class<? extends InterconnectObject>, RegistryEntry> registry;
+
+    /**
+     * @param aHandlerClazz the handler class
+     */
+    public DaemonMethodRegistry(final Class<? extends IDaemonHandler> aHandlerClazz) {
+        final Map<Class<? extends InterconnectObject>, RegistryEntry> reg = new HashMap<>();
+        for (final DaemonScanner.DaemonMethod re : DaemonScanner.scan(aHandlerClazz)) {
+            reg.put(re.getRequest(), new RegistryEntry(aHandlerClazz, re));
+        }
+        this.registry = Collections.unmodifiableMap(reg);
+    }
+
+    /**
+     * @param aHandlerClazzes all handler classes
+     */
+    public DaemonMethodRegistry(final Collection<Class<? extends IDaemonHandler>> aHandlerClazzes) {
+        final Map<Class<? extends InterconnectObject>, RegistryEntry> reg = new HashMap<>();
+        for (Class<? extends IDaemonHandler> aHandlerClazz : aHandlerClazzes) {
+            for (final DaemonScanner.DaemonMethod re : DaemonScanner.scan(aHandlerClazz)) {
+                reg.put(re.getRequest(), new RegistryEntry(aHandlerClazz, re));
+            }
+        }
+        this.registry = Collections.unmodifiableMap(reg);
+    }
+
+    /**
+     * @param icoClass the interconnect object class
+     * @return the registry entry
+     */
+    public RegistryEntry get(Class<? extends InterconnectObject> icoClass) {
+        return this.registry.get(icoClass);
+    }
+
+    /**
+     * @param icoClass the interconnect object class
+     * @return the daemon method
+     */
+    public DaemonMethod getMethod(Class<? extends InterconnectObject> icoClass) {
+        RegistryEntry registryEntry = this.registry.get(icoClass);
+        if (registryEntry == null) {
+            return null;
+        }
+        return registryEntry.getMethod();
+    }
+
+    public static class RegistryEntry {
+        private final Class<? extends IDaemonHandler> aHandlerClazz;
+        private final DaemonMethod method;
+
+        RegistryEntry(Class<? extends IDaemonHandler> aHandlerClazz, DaemonMethod method) {
+            this.aHandlerClazz = aHandlerClazz;
+            this.method = method;
+        }
+
+        /**
+         * @return the aHandlerClazz
+         */
+        public Class<? extends IDaemonHandler> getHandlerClazz() {
+            return this.aHandlerClazz;
+        }
+
+        /**
+         * @return the method
+         */
+        public DaemonMethod getMethod() {
+            return this.method;
+        }
+    }
+}

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/IDaemonMessageHandlerFactory.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/IDaemonMessageHandlerFactory.java
@@ -4,7 +4,7 @@ import de.taimos.dvalin.interconnect.core.daemon.ADaemonMessageHandler;
 import org.slf4j.Logger;
 
 /**
- * Copyright 2022 Cinovo AG<br>
+ *  Copyright 2022 Taimos GmbH<br>
  * <br>
  *
  * @author psigloch

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/IDaemonMessageHandlerFactory.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/IDaemonMessageHandlerFactory.java
@@ -1,0 +1,18 @@
+package de.taimos.dvalin.interconnect.core.spring;
+
+import de.taimos.dvalin.interconnect.core.daemon.ADaemonMessageHandler;
+import org.slf4j.Logger;
+
+/**
+ * Copyright 2022 Cinovo AG<br>
+ * <br>
+ *
+ * @author psigloch
+ */
+public interface IDaemonMessageHandlerFactory {
+    /**
+     * @param logger the logger to use within the message handler
+     * @return the message handler
+     */
+    ADaemonMessageHandler create(Logger logger);
+}

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/MultiDaemonMessageHandler.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/MultiDaemonMessageHandler.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.BeanFactory;
 import java.util.Collection;
 
 /**
- * Copyright 2022 Cinovo AG<br>
+ *  Copyright 2022 Taimos GmbH<br>
  * <br>
  *
  * @author psigloch

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/MultiDaemonMessageHandler.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/MultiDaemonMessageHandler.java
@@ -1,0 +1,54 @@
+package de.taimos.dvalin.interconnect.core.spring;
+
+import de.taimos.dvalin.interconnect.core.daemon.ADaemonMessageHandler;
+import de.taimos.dvalin.interconnect.core.daemon.DaemonMethodRegistry.RegistryEntry;
+import de.taimos.dvalin.interconnect.core.daemon.DaemonResponse;
+import de.taimos.dvalin.interconnect.model.service.IDaemonHandler;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.BeanFactory;
+
+import java.util.Collection;
+
+/**
+ * Copyright 2022 Cinovo AG<br>
+ * <br>
+ *
+ * @author psigloch
+ */
+public class MultiDaemonMessageHandler extends ADaemonMessageHandler {
+
+    private final Logger logger;
+
+    private final IDaemonMessageSender messageSender;
+
+    private final BeanFactory beanFactory;
+
+
+    /**
+     * @param aLogger         the logger
+     * @param aHandlerClazzes the handler classes
+     * @param aMessageSender  the message sender
+     * @param beanFactory     the bean factory
+     */
+    public MultiDaemonMessageHandler(final Logger aLogger, final Collection<Class<? extends IDaemonHandler>> aHandlerClazzes, final IDaemonMessageSender aMessageSender, BeanFactory beanFactory) {
+        super(aHandlerClazzes, false);
+        this.logger = aLogger;
+        this.messageSender = aMessageSender;
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    protected void reply(final DaemonResponse response, final boolean secure) throws Exception {
+        this.messageSender.reply(response, secure);
+    }
+
+    @Override
+    protected IDaemonHandler createRequestHandler(RegistryEntry registryEntry) {
+        return this.beanFactory.getBean(registryEntry.getHandlerClazz());
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return this.logger;
+    }
+}

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/SingleDaemonMessageHandler.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/SingleDaemonMessageHandler.java
@@ -1,0 +1,53 @@
+package de.taimos.dvalin.interconnect.core.spring;
+
+import de.taimos.dvalin.interconnect.core.daemon.ADaemonMessageHandler;
+import de.taimos.dvalin.interconnect.core.daemon.DaemonMethodRegistry.RegistryEntry;
+import de.taimos.dvalin.interconnect.core.daemon.DaemonResponse;
+import de.taimos.dvalin.interconnect.model.service.ADaemonHandler;
+import de.taimos.dvalin.interconnect.model.service.IDaemonHandler;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.BeanFactory;
+
+/**
+ * Copyright 2022 Cinovo AG<br>
+ * <br>
+ *
+ * @author psigloch
+ */
+public class SingleDaemonMessageHandler extends ADaemonMessageHandler {
+
+    private final Logger logger;
+
+    private final IDaemonMessageSender messageSender;
+
+    private final BeanFactory beanFactory;
+
+
+    /**
+     * @param aLogger        the logger
+     * @param aHandlerClazz  the handler clazz
+     * @param aMessageSender the message sender
+     * @param beanFactory    the bean factory
+     */
+    public SingleDaemonMessageHandler(final Logger aLogger, final Class<? extends ADaemonHandler> aHandlerClazz, final IDaemonMessageSender aMessageSender, BeanFactory beanFactory) {
+        super(aHandlerClazz, false);
+        this.logger = aLogger;
+        this.messageSender = aMessageSender;
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    protected void reply(final DaemonResponse response, final boolean secure) throws Exception {
+        this.messageSender.reply(response, secure);
+    }
+
+    @Override
+    protected IDaemonHandler createRequestHandler(RegistryEntry registryEntry) {
+        return (ADaemonHandler) this.beanFactory.getBean("requestHandler");
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return this.logger;
+    }
+}

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/SingleDaemonMessageHandler.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/spring/SingleDaemonMessageHandler.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
 
 /**
- * Copyright 2022 Cinovo AG<br>
+ *  Copyright 2022 Taimos GmbH<br>
  * <br>
  *
  * @author psigloch


### PR DESCRIPTION
We have some services which are not quite as "micro" as they should be.
Those normaly provide multiple interfaces for the interconnect, which currently all have to be implemented in one Class, annotating @RequestHandler.

This pull request aims to add support to make it possible to use multiple classes annotated with @RequestHandler.
The suggested implementation is additive and does not change the behaviour of the current implementation.
Multi-RequestHandler Support has to be activated by setting the property "interconnect.requesthandler.mode" to "multi", otherwise the behaviour does not change and only the default requesthandler will be used.
If using the multi version, each additional @RequestHandler has to have a unique value.

This would help us to better maintain and scope our code.

In addition I removed some long time deprecated methods in touched classes.