### PR TITLE
adds a systemproperty to reconfigure the timeout of interconnect daem…

### DIFF
--- a/interconnect/model/src/main/java/de/taimos/dvalin/interconnect/model/service/DaemonScanner.java
+++ b/interconnect/model/src/main/java/de/taimos/dvalin/interconnect/model/service/DaemonScanner.java
@@ -238,7 +238,10 @@ public final class DaemonScanner {
             throw new IllegalStateException("Paramater of @DaemonRequestMethod must not be an interface");
         }
         @SuppressWarnings("unchecked") final Class<? extends InterconnectObject> icoClazz = (Class<? extends InterconnectObject>) method.getParameterTypes()[0];
-        final long timeoutInMs = drm.timeoutUnit().toMillis(drm.timeout());
+
+        long timeout = Long.parseLong(System.getProperty("interconnect.forcetimeout." + method.getDeclaringClass().getSimpleName() + "." + method.getName(), String.valueOf(drm.timeout())));
+        final long timeoutInMs = drm.timeoutUnit().toMillis(timeout);
+
         return new DaemonMethod(icoClazz, method, type, timeoutInMs, drm.secure(), drm.idempotent());
     }
 


### PR DESCRIPTION
In some cases, due to network bahviour or other temporary issues, it might be that some interconnect messages need more time to be answered than in normal circumstances.
To be able to temporarily circumvent such issues, this commit introduces an optional SystemProperty to temporarily overwrite the timeout configuration of a specific DaemonMethod:

`interconnect.forcetimeout.${interfaceName}.${methodName}=long`

With ${interfaceName} beeing the simple name of the IDaemon interface implementation and ${methodName} beeing the method name.
As timeUnit, the configured timeUnit of the DaemonMethod will be used.

This is an additive option. It does not change the current behaviour as long as the property is not set.