### PR TITLE
Replace deprecated hibernate-entitymanager with hibernate-core

### DIFF
--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -17,7 +17,7 @@
 
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
+            <artifactId>hibernate-core</artifactId>
         </dependency>
 
         <!-- Transaction Management Abstraction (depends on spring-core, spring-beans, spring-aop, spring-context) Define this if you use Spring Transactions

--- a/pom.xml
+++ b/pom.xml
@@ -350,11 +350,6 @@
 
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
-                <version>${hibernate.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate.version}</version>
             </dependency>


### PR DESCRIPTION
hibernate-entitymanager pom says:
<name>Hibernate ORM - hibernate-entitymanager</name>
  <description>(deprecated - use hibernate-core instead) Hibernate O/RM implementation of the JPA specification</description>