### PR TITLE
i18n resources from XML and YAML

### DIFF
--- a/i18n/src/main/java/de/taimos/dvalin/i18n/I18nLoader.java
+++ b/i18n/src/main/java/de/taimos/dvalin/i18n/I18nLoader.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * @author aeichel/psigloch
@@ -47,7 +48,17 @@ public class I18nLoader implements II18nCallback, II18nAccess {
 
     @Override
     public void addText(Map<String, Map<String, String>> elements) {
-        I18nLoader.stringMap.putAll(elements);
+        for (Entry<String, Map<String, String>> languageEntry : elements.entrySet()) {
+            String language = languageEntry.getKey();
+            Map<String, String> additionalResourcesMap = languageEntry.getValue();
+
+            Map<String, String> existingResourcesMap = I18nLoader.stringMap.get(language);
+            if (existingResourcesMap != null) {
+                existingResourcesMap.putAll(additionalResourcesMap);
+            } else {
+                I18nLoader.stringMap.put(language, new HashMap<>(additionalResourcesMap));
+            }
+        }
     }
 
     @Override
@@ -67,7 +78,7 @@ public class I18nLoader implements II18nCallback, II18nAccess {
             if(!usedLocal.equals(this.DEFAULT_LOCALE)) {
                 return this.getString(this.DEFAULT_LOCALE, identifier);
             }
-            I18nLoader.LOGGER.error("Did not find text key " + identifier);
+            I18nLoader.LOGGER.error("Did not find text key '{}'", identifier);
             return '!' + identifier + '!';
         }
         return theResult;

--- a/i18n/src/test/java/de/taimos/dvalin/i18n/ResourceFrameworkXmlAndYamlTest.java
+++ b/i18n/src/test/java/de/taimos/dvalin/i18n/ResourceFrameworkXmlAndYamlTest.java
@@ -1,0 +1,50 @@
+package de.taimos.dvalin.i18n;
+
+import de.taimos.dvalin.i18n.xml.I18nXMLHandler;
+import de.taimos.dvalin.i18n.yaml.I18nYAMLHandler;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.core.io.Resource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author mweise
+ */
+public class ResourceFrameworkXmlAndYamlTest extends AbstractResourceFrameworkTest {
+
+    @Override
+    protected List<II18nResourceHandler> getResourceHandler() {
+        List<II18nResourceHandler> resourceHandlers = new ArrayList<>();
+
+        I18nXMLHandler xmlHandler = new I18nXMLHandler();
+        Resource xml = AbstractResourceFrameworkTest.findResource("i18n/test.xml");
+        AbstractResourceFrameworkTest.injectValue(xmlHandler, "resourceFiles", new Resource[]{xml});
+        Resource schema = AbstractResourceFrameworkTest.findResource("schema/i18nSchema_v1.xsd");
+        AbstractResourceFrameworkTest.injectValue(xmlHandler, "resourceSchema", new Resource[]{schema});
+        resourceHandlers.add(xmlHandler);
+
+        I18nYAMLHandler yamlHandler = new I18nYAMLHandler();
+        Resource yaml = AbstractResourceFrameworkTest.findResource("i18n/test.yaml");
+        AbstractResourceFrameworkTest.injectValue(yamlHandler, "resourceFiles", new Resource[]{yaml});
+        resourceHandlers.add(yamlHandler);
+        return resourceHandlers;
+    }
+
+    @Test
+    public void testXMLandYAMLFiles() {
+        {
+            //default locale
+            String text = this.resourceAccess.getString("xmlOnly");
+            Assert.assertEquals("nur in XML", text);
+        }
+
+        {
+            //fixed locale
+            String text = this.resourceAccess.getString(Locale.ENGLISH, "yamlOnly");
+            Assert.assertEquals("only in YAML", text);
+        }
+    }
+}

--- a/i18n/src/test/resources/i18n/test.xml
+++ b/i18n/src/test/resources/i18n/test.xml
@@ -16,4 +16,8 @@
         <language locale="de" value="EnumFieldBGerman" />
         <language locale="en" value="EnumFieldBEnglish"/>
     </label>
+    <label id="xmlOnly">
+        <language locale="de" value="nur in XML" />
+        <language locale="en" value="only in xml" />
+    </label>
 </i18nBundle>

--- a/i18n/src/test/resources/i18n/test.yaml
+++ b/i18n/src/test/resources/i18n/test.yaml
@@ -10,3 +10,6 @@ de.taimos.dvalin.i18n.TestEnum.FIELD_A:
 de.taimos.dvalin.i18n.TestEnum.FIELD_B:
   de: EnumFieldBGerman
   en: EnumFieldBEnglish
+yamlOnly:
+  de: nur in YAML
+  en: only in YAML


### PR DESCRIPTION
Loading i18n resources from both XML and YAML files is not possible at the moment because YAML resource maps replace all resources already loaded from XML files.

With this PR resource maps are merged.