### PR TITLE
Updating Jacoco Maven Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     * Hazelcast 5.1.3
     * XDocReport 2.0.4
     * Bouncycastle Provider 1.71.1
+    * Jacoco Maven Plugin 0.8.8
 
 * Moved Mongo Java Server to optional dependency (in most cases Fake Mongo is not needed or can be added)
 * BREAKING: replaced mongobee with Mongock (5.0.36), mostly backwards compatibility but configuration(see Class `MongoDBConfig`) and annotations (@Changelog and @ChangeSet) have to be replaced by Mongock equivalent https://docs.mongock.io/v5/features/legacy-migration/index.html  

--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.6.201602180812</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The old version of Jacoco Maven Plugin results in error with new version of Sonarqube Scanner and avoids analysing the code.
Update seems unproblematic.