### PR TITLE
fixing a problem with activemq and avoidable reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * Moved Mongo Java Server to optional dependency (in most cases Fake Mongo is not needed or can be added)
 * BREAKING: replaced mongobee with Mongock (5.1.6), mostly backwards compatibility but configuration(see Class `MongoDBConfig`) and annotations (@Changelog and @ChangeSet) have to be replaced by Mongock equivalent https://docs.mongock.io/v5/features/legacy-migration/index.html  
+* Fixed problem in ActiveMQ with use of pooled connections on event listeners that causes avoidable regular reconnects
 
 ## 1.32
 * Update dependencies

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/JMSConfig.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/config/JMSConfig.java
@@ -34,6 +34,7 @@ import de.taimos.dvalin.interconnect.model.service.ADaemonHandler;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -65,7 +66,7 @@ public class JMSConfig {
     @Value("${interconnect.jms.password:}")
     private String password;
 
-    @Bean
+    @Bean(name = "DvalinConnectionFactory")
     public ConnectionFactory jmsConnectionFactory() {
         return new DvalinConnectionFactory(this.brokerUrl, this.userName, this.password);
 
@@ -107,7 +108,7 @@ public class JMSConfig {
     }
 
     @Bean
-    public DefaultMessageListenerContainer jmsListenerContainer(PooledConnectionFactory jmsFactory, DaemonMessageListener messageListener) {
+    public DefaultMessageListenerContainer jmsListenerContainer(@Qualifier("DvalinConnectionFactory") ConnectionFactory jmsFactory, DaemonMessageListener messageListener) {
         DefaultMessageListenerContainer dmlc = new DefaultMessageListenerContainer();
         dmlc.setConnectionFactory(jmsFactory);
         dmlc.setErrorHandler(messageListener);

--- a/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/event/EventMessageListener.java
+++ b/interconnect/core/src/main/java/de/taimos/dvalin/interconnect/core/event/EventMessageListener.java
@@ -32,6 +32,7 @@ import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -41,6 +42,7 @@ import org.springframework.util.ErrorHandler;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import javax.jms.TextMessage;
@@ -66,7 +68,8 @@ public class EventMessageListener implements MessageListener, ErrorHandler {
     private String consumerPrefix;
 
     @Autowired
-    private PooledConnectionFactory jmsFactory;
+    @Qualifier("DvalinConnectionFactory")
+    private ConnectionFactory jmsFactory;
     @Autowired
     private ApplicationContext applicationContext;
 


### PR DESCRIPTION
* Fixed problem in ActiveMQ with use of pooled connections on event listeners that causes avoidable regular reconnects