### PR TITLE
Log4jDaemonProperties.getCustomLevelMap no longer gives back immutableMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * Moved Mongo Java Server to optional dependency (in most cases Fake Mongo is not needed or can be added)
 * BREAKING: replaced mongobee with Mongock (5.1.6), mostly backwards compatibility but configuration(see Class `MongoDBConfig`) and annotations (@Changelog and @ChangeSet) have to be replaced by Mongock equivalent https://docs.mongock.io/v5/features/legacy-migration/index.html  
+* Log4jDaemonProperties.getCustomLevelMap no longer gives back immutableMap with empty configString. This was unexpected when you want to add values afterwards.
 
 ## 1.32
 * Update dependencies

--- a/daemon/src/main/java/de/taimos/daemon/log4j/Log4jDaemonProperties.java
+++ b/daemon/src/main/java/de/taimos/daemon/log4j/Log4jDaemonProperties.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.SyslogAppender;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -81,7 +80,7 @@ public final class Log4jDaemonProperties {
 
     public static Map<String, Level> getCustomLevelMap(String configString, Level defaultLevel) {
         if (configString == null || configString.isEmpty()) {
-            return Collections.emptyMap();
+            return new HashMap<>();
         }
 
         Pattern configSeparator = Pattern.compile(";");


### PR DESCRIPTION
* Log4jDaemonProperties.getCustomLevelMap no longer gives back immutableMap with empty configString. This was unexpected when you want to add values afterwards.on**: