### PR TITLE
updating dependencies, fixing vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
     * Jetty 9.4.51.v20230217
     * Apache CXF 3.5.6
     * JSON Small and Fast Parser 2.4.9
+    * Jackson 2.15.2
+    * Guava 32.0.0
+    * Hazelcast 5.3.0
+    * Swagger 2.2.10
+    * Liquibase 4.21.1
 * Fixed vulnerabilities: CVE-2023-26048, CVE-2023-26049, CVE-2023-1370, CVE-2023-20861, CVE-2023-20863, CVE-2023-1370, 
-CVE-2022-40152, CVE-2022-46364, CVE-2022-46363
+CVE-2022-40152, CVE-2022-46364, CVE-2022-46363, CVE-2023-2976, CVE-2020-8908, CVE-2022-1471, CVE-2023-33264
 
 # 1.33
 * Update dependencies

--- a/cluster/hazelcast/pom.xml
+++ b/cluster/hazelcast/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>dvalin-cluster-hazelcast</artifactId>
     <name>Dvalin Hazelcast support</name>
     <properties>
-        <hazelcast.version>5.1.4</hazelcast.version>
+        <hazelcast.version>5.3.0</hazelcast.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jaxrs-swagger/pom.xml
+++ b/jaxrs-swagger/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.10</version>
         </dependency>
 
         <dependency>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-jaxrs2</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.10</version>
         </dependency>
 
         <dependency>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.17.2</version>
+            <version>4.21.1</version>
         </dependency>
         <dependency>
             <groupId>com.mattbertolini</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     </contributors>
     <properties>
         <org.springframework.version>5.3.27</org.springframework.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
         <joda.time.version>2.11.2</joda.time.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.19.0</log4j.version>
@@ -61,7 +61,7 @@
         <activemq.version>5.16.5</activemq.version>
         <cxf.version>3.5.6</cxf.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
-        <guava.version>31.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <hibernate.version>5.6.14.Final</hibernate.version>
         <http.version>2.2</http.version>
         <velocity.version>2.3</velocity.version>


### PR DESCRIPTION
* Update dependencies
    * Jackson 2.15.2
    * Guava 32.0.0
    * Hazelcast 5.3.0
    * Swagger 2.2.10
    * Liquibase 4.21.1
* Fixed vulnerabilities:
CVE-2023-2976, CVE-2020-8908, CVE-2022-1471, CVE-2023-33264