### PR TITLE
Add annotation that enables additional test runner configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     * Liquibase 4.21.1
 * Fixed vulnerabilities: CVE-2023-26048, CVE-2023-26049, CVE-2023-1370, CVE-2023-20861, CVE-2023-20863, CVE-2023-1370, 
 CVE-2022-40152, CVE-2022-46364, CVE-2022-46363, CVE-2023-2976, CVE-2020-8908, CVE-2022-1471, CVE-2023-33264
+* Added support for additional configuration files when using SpringDaemonTestRunner
 
 # 1.33
 * Update dependencies

--- a/daemon/src/main/java/de/taimos/daemon/spring/SpringDaemonTestRunner.java
+++ b/daemon/src/main/java/de/taimos/daemon/spring/SpringDaemonTestRunner.java
@@ -21,6 +21,16 @@ package de.taimos.daemon.spring;
  */
 
 
+import de.taimos.daemon.DaemonProperties;
+import de.taimos.daemon.ILoggingConfigurer;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -32,240 +42,284 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.runners.BlockJUnit4ClassRunner;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-
-import de.taimos.daemon.DaemonProperties;
-import de.taimos.daemon.ILoggingConfigurer;
-
 public class SpringDaemonTestRunner extends BlockJUnit4ClassRunner {
 
-	private static final Logger logger = LoggerFactory.getLogger(SpringDaemonTestRunner.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpringDaemonTestRunner.class);
 
-	private SpringTest springTest;
-
-
-	/**
-	 * @param klass the class
-	 * @throws InitializationError on error
-	 */
-	public SpringDaemonTestRunner(Class<?> klass) throws InitializationError {
-		super(klass);
-	}
-
-	@Override
-	protected Statement methodInvoker(FrameworkMethod method, Object test) {
-		final Statement invoker = super.methodInvoker(method, test);
-		return new Statement() {
-
-			@Override
-			public void evaluate() throws Throwable {
-				invoker.evaluate();
-			}
-		};
-	}
-
-	@Override
-	protected Statement withAfterClasses(Statement statement) {
-		final Statement next = super.withAfterClasses(statement);
-		return new Statement() {
-
-			@Override
-			public void evaluate() throws Throwable {
-				next.evaluate();
-				SpringDaemonTestRunner.this.springTest.stop();
-			}
-		};
-	}
-
-	@Override
-	protected Statement withBeforeClasses(Statement statement) {
-		final Statement next = super.withBeforeClasses(statement);
-		return new Statement() {
-
-			@Override
-			public void evaluate() throws Throwable {
-				final RunnerConfiguration cfgClass = this.findConfigAnnotation(SpringDaemonTestRunner.this.getTestClass().getJavaClass());
-				if (cfgClass == null) {
-					// Die on missing annotation
-					throw new RuntimeException("Missing @RunnerConfiguration");
-				}
-
-				ILoggingConfigurer lc = cfgClass.loggingConfigurer().newInstance();
-				lc.simpleLogging();
-
-				final RunnerConfig cfg;
-				cfg = cfgClass.config().newInstance();
-				cfg.addProperty(DaemonProperties.SERVICE_NAME, cfgClass.svc());
-				cfg.addProperty("profiles", "test");
-				cfg.addProperty(DaemonProperties.STARTUP_MODE, DaemonProperties.STARTUP_MODE_DEV);
-				try {
-					SpringDaemonTestRunner.this.springTest = new SpringTest() {
-
-						@Override
-						protected String getServiceName() {
-							return cfgClass.svc();
-						}
-
-						@Override
-						protected void fillProperties(Map<String, String> props) {
-							String servicePackage = cfg.getServicePackage();
-							if (servicePackage != null) {
-								props.put(Configuration.SERVICE_PACKAGE, servicePackage);
-								System.setProperty(Configuration.SERVICE_PACKAGE, servicePackage);
-							}
-
-							Enumeration<?> names = cfg.getProps().propertyNames();
-							while (names.hasMoreElements()) {
-								String key = (String) names.nextElement();
-								props.put(key, cfg.getProps().getProperty(key));
-							}
-						}
-
-						@Override
-						protected String getSpringResource() {
-							return cfg.getSpringFile();
-						}
-
-						@Override
-						protected void doAfterSpringStart() {
-							List<Method> methods = findAfterStartupAnnotatedMethods(SpringDaemonTestRunner.this.getTestClass().getJavaClass());
-							for (Method method : methods) {
-								try {
-									method.invoke(SpringDaemonTestRunner.this.createTest());
-								} catch (Exception e) {
-									throw new RuntimeException("Starting Spring context failed", e);
-								}
-							}
-						}
-
-					};
-					SpringDaemonTestRunner.this.springTest.start();
-					next.evaluate();
-				} catch (BeansException | IllegalStateException e) {
-					SpringDaemonTestRunner.logger.error("Starting Spring context failed", e);
-					throw new RuntimeException("Starting Spring context failed", e);
-				}
-			}
-
-			private RunnerConfiguration findConfigAnnotation(Class<?> clazz) {
-				if (clazz == null) {
-					return null;
-				}
-				RunnerConfiguration cfgClass = clazz.getAnnotation(RunnerConfiguration.class);
-				if (cfgClass == null) {
-					cfgClass = this.findConfigAnnotation(clazz.getSuperclass());
-				}
-				return cfgClass;
-			}
-
-			private List<Method> findAfterStartupAnnotatedMethods(Class<?> clazz) {
-				List<Method> res = new ArrayList<>();
-				if (clazz == null) {
-					return res;
-				}
-				Method[] methods = clazz.getMethods();
-				for (Method method : methods) {
-					if (method.isAnnotationPresent(AfterStartup.class) && (method.getParameterTypes().length == 0)) {
-						res.add(method);
-					}
-				}
-				return res;
-			}
-		};
-	}
-
-	@Override
-	protected Object createTest() throws Exception {
-		return this.springTest.getContext().getBeanFactory().createBean(this.getTestClass().getJavaClass());
-	}
+    private SpringTest springTest;
 
 
-	/**
-	 * Copyright 2013 Cinovo AG<br>
-	 * <br>
-	 *
-	 * @author thoeger
-	 *
-	 */
-	public static class RunnerConfig {
+    /**
+     * @param klass the class
+     * @throws InitializationError on error
+     */
+    public SpringDaemonTestRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
 
-		private final Properties props = new Properties();
+    @Override
+    protected Statement methodInvoker(FrameworkMethod method, Object test) {
+        final Statement invoker = super.methodInvoker(method, test);
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                invoker.evaluate();
+            }
+        };
+    }
+
+    @Override
+    protected Statement withAfterClasses(Statement statement) {
+        final Statement next = super.withAfterClasses(statement);
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                next.evaluate();
+                SpringDaemonTestRunner.this.springTest.stop();
+            }
+        };
+    }
+
+    @Override
+    protected Statement withBeforeClasses(Statement statement) {
+        final Statement next = super.withBeforeClasses(statement);
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                final RunnerConfiguration cfgClass = this.findConfigAnnotation(
+                    SpringDaemonTestRunner.this.getTestClass().getJavaClass());
+                if (cfgClass == null) {
+                    // Die on missing annotation
+                    throw new RuntimeException("Missing @RunnerConfiguration");
+                }
+
+                ILoggingConfigurer lc = cfgClass.loggingConfigurer().newInstance();
+                lc.simpleLogging();
+
+                final RunnerConfig cfg;
+                cfg = cfgClass.config().newInstance();
+                cfg.addProperty(DaemonProperties.SERVICE_NAME, cfgClass.svc());
+                cfg.addProperty("profiles", "test");
+                cfg.addProperty(DaemonProperties.STARTUP_MODE, DaemonProperties.STARTUP_MODE_DEV);
+
+                final AdditionalRunnerConfiguration addCfgClass = this.findAdditionalConfigAnnotation(
+                    SpringDaemonTestRunner.this.getTestClass().getJavaClass());
+                if (addCfgClass != null) {
+                    SpringDaemonTestRunner.logger.trace("Adding additional configurations to test.");
+                    for (Class<? extends TestConfiguration> aClass : addCfgClass.config()) {
+                        aClass.newInstance().getProps().forEach((o, o2) -> cfg.addProperty((String) o, (String) o2));
+                    }
+                }
+                try {
+                    SpringDaemonTestRunner.this.springTest = this.getConfiguredSpringTest(cfgClass, cfg);
+                    SpringDaemonTestRunner.this.springTest.start();
+                    next.evaluate();
+                } catch (BeansException | IllegalStateException e) {
+                    SpringDaemonTestRunner.logger.error("Starting Spring context failed", e);
+                    throw new RuntimeException("Starting Spring context failed", e);
+                }
+            }
+
+            private SpringTest getConfiguredSpringTest(RunnerConfiguration cfgClass, RunnerConfig cfg) {
+                return new SpringTest() {
+
+                    @Override
+                    protected String getServiceName() {
+                        return cfgClass.svc();
+                    }
+
+                    @Override
+                    protected void fillProperties(Map<String, String> props) {
+                        String servicePackage = cfg.getServicePackage();
+                        if (servicePackage != null) {
+                            props.put(Configuration.SERVICE_PACKAGE, servicePackage);
+                            System.setProperty(Configuration.SERVICE_PACKAGE, servicePackage);
+                        }
+
+                        Enumeration<?> names = cfg.getProps().propertyNames();
+                        while (names.hasMoreElements()) {
+                            String key = (String) names.nextElement();
+                            props.put(key, cfg.getProps().getProperty(key));
+                        }
+                    }
+
+                    @Override
+                    protected String getSpringResource() {
+                        return cfg.getSpringFile();
+                    }
+
+                    @Override
+                    protected void doAfterSpringStart() {
+                        List<Method> methods = this.findAfterStartupAnnotatedMethods(
+                            SpringDaemonTestRunner.this.getTestClass().getJavaClass());
+                        for (Method method : methods) {
+                            try {
+                                method.invoke(SpringDaemonTestRunner.this.createTest());
+                            } catch (Exception e) {
+                                throw new RuntimeException("Starting Spring context failed", e);
+                            }
+                        }
+                    }
+
+                    private List<Method> findAfterStartupAnnotatedMethods(Class<?> clazz) {
+                        List<Method> res = new ArrayList<>();
+                        if (clazz == null) {
+                            return res;
+                        }
+                        Method[] methods = clazz.getMethods();
+                        for (Method method : methods) {
+                            if (method.isAnnotationPresent(AfterStartup.class) &&
+                                (method.getParameterTypes().length == 0)) {
+                                res.add(method);
+                            }
+                        }
+                        return res;
+                    }
+
+                };
+            }
+
+            private RunnerConfiguration findConfigAnnotation(Class<?> clazz) {
+                if (clazz == null) {
+                    return null;
+                }
+                RunnerConfiguration cfgClass = clazz.getAnnotation(RunnerConfiguration.class);
+                if (cfgClass == null) {
+                    cfgClass = this.findConfigAnnotation(clazz.getSuperclass());
+                }
+                return cfgClass;
+            }
+
+            private AdditionalRunnerConfiguration findAdditionalConfigAnnotation(Class<?> clazz) {
+                if (clazz == null) {
+                    return null;
+                }
+                AdditionalRunnerConfiguration cfgClass = clazz.getAnnotation(AdditionalRunnerConfiguration.class);
+                if (cfgClass == null) {
+                    cfgClass = this.findAdditionalConfigAnnotation(clazz.getSuperclass());
+                }
+                return cfgClass;
+            }
+
+        };
+    }
+
+    @Override
+    protected Object createTest() throws Exception {
+        return this.springTest.getContext().getBeanFactory().createBean(this.getTestClass().getJavaClass());
+    }
 
 
-		/**
-		 * @param key the prop key
-		 * @param value the prop value
-		 */
-		protected void addProperty(final String key, final String value) {
-			this.props.setProperty(key.trim(), value);
-		}
+    /**
+     * Copyright 2013 Cinovo AG<br>
+     * <br>
+     *
+     * @author thoeger
+     */
+    public static class RunnerConfig implements TestConfiguration {
 
-		/**
-		 * @return the properties
-		 */
-		public Properties getProps() {
-			return this.props;
-		}
+        private final Properties props = new Properties();
 
-		/**
-		 * @return the Spring file nme
-		 */
-		public String getSpringFile() {
-			return "spring-test/beans.xml";
-		}
 
-		public String getServicePackage() {
-			return null;
-		}
+        /**
+         * @param key   the prop key
+         * @param value the prop value
+         */
+        protected void addProperty(final String key, final String value) {
+            this.props.setProperty(key.trim(), value);
+        }
 
-		protected static Integer randomPort() {
-			return (int) ((Math.random() * 20000) + 10000);
-		}
-	}
+        @Override
+        public Properties getProps() {
+            return this.props;
+        }
 
-	/**
-	 * Copyright 2013 Cinovo AG<br>
-	 * <br>
-	 *
-	 * @author thoeger
-	 *
-	 */
-	@Target({ElementType.TYPE})
-	@Retention(RetentionPolicy.RUNTIME)
-	public @interface RunnerConfiguration {
+        /**
+         * @return the Spring file nme
+         */
+        public String getSpringFile() {
+            return "spring-test/beans.xml";
+        }
 
-		/**
-		 * @return the class
-		 */
-		Class<? extends RunnerConfig> config() default RunnerConfig.class;
+        /**
+         * @return the package reference of the service
+         */
+        public String getServicePackage() {
+            return null;
+        }
 
-		/**
-		 * @return the service name
-		 */
-		String svc();
+        protected static Integer randomPort() {
+            return (int) ((Math.random() * 20000) + 10000);
+        }
+    }
 
-		/**
-		 * @return the logging configurer
-		 */
-		Class<? extends ILoggingConfigurer> loggingConfigurer();
-	}
+    /**
+     * Copyright 2013 Cinovo AG<br>
+     * <br>
+     *
+     * @author thoeger
+     */
+    @Target({ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface RunnerConfiguration {
 
-	/**
-	 * Copyright 2014 Taimos GmbH<br>
-	 * <br>
-	 *
-	 * @author thoeger
-	 *
-	 */
-	@Target({ElementType.METHOD})
-	@Retention(RetentionPolicy.RUNTIME)
-	public @interface AfterStartup {
-		//
-	}
+        /**
+         * @return the class
+         */
+        Class<? extends RunnerConfig> config() default RunnerConfig.class;
+
+        /**
+         * @return the service name
+         */
+        String svc();
+
+        /**
+         * @return the logging configurer
+         */
+        Class<? extends ILoggingConfigurer> loggingConfigurer();
+    }
+
+    /**
+     * Copyright 2014 Taimos GmbH<br>
+     * <br>
+     *
+     * @author thoeger
+     */
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AfterStartup {
+        //
+    }
+
+    /**
+     * Copyright 2023 Cinovo AG<br>
+     * <br>
+     *
+     * @author fzwirn
+     */
+    public interface TestConfiguration {
+        /**
+         * @return the properties for this runner configuration
+         */
+        Properties getProps();
+    }
+
+
+    /**
+     * Copyright 2023 Cinovo AG<br>
+     * <br>
+     *
+     * @author fzwirn
+     */
+    @Target({ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AdditionalRunnerConfiguration {
+        /**
+         * @return the class
+         */
+        Class<? extends TestConfiguration>[] config() default {};
+    }
 }

--- a/daemon/src/test/java/de/taimos/dvalin/daemon/AdditionalConfigTest.java
+++ b/daemon/src/test/java/de/taimos/dvalin/daemon/AdditionalConfigTest.java
@@ -1,0 +1,35 @@
+package de.taimos.dvalin.daemon;
+
+import de.taimos.daemon.log4j.Log4jLoggingConfigurer;
+import de.taimos.daemon.spring.SpringDaemonTestRunner;
+import de.taimos.daemon.spring.SpringDaemonTestRunner.AdditionalRunnerConfiguration;
+import de.taimos.daemon.spring.SpringDaemonTestRunner.RunnerConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Copyright 2023 Cinovo AG<br>
+ * <br>
+ *
+ * @author fzwirn
+ */
+@RunWith(SpringDaemonTestRunner.class)
+@RunnerConfiguration(config = DvalinTestRunnerConfig.class, loggingConfigurer = Log4jLoggingConfigurer.class, svc = "AdditionalConfigTest")
+@AdditionalRunnerConfiguration(config = {AdditionalTestConfig.class})
+public class AdditionalConfigTest {
+
+    @Value("${jwtauth.issuer}")
+    private String jwtIssuer;
+
+    /**
+     * Test if the property from {@link AdditionalTestConfig} was set up.
+     */
+    @Test
+    public void testAdditionalConfiguration() {
+        assertEquals("The propery 'jwtauth.issuer' was not equals to the value of AdditionalTestConfig.TEST_VALUE",
+            AdditionalTestConfig.TEST_VALUE, this.jwtIssuer);
+    }
+}

--- a/daemon/src/test/java/de/taimos/dvalin/daemon/AdditionalTestConfig.java
+++ b/daemon/src/test/java/de/taimos/dvalin/daemon/AdditionalTestConfig.java
@@ -1,0 +1,23 @@
+package de.taimos.dvalin.daemon;
+
+import de.taimos.daemon.spring.SpringDaemonTestRunner.TestConfiguration;
+
+import java.util.Properties;
+
+/**
+ * Copyright 2023 Cinovo AG<br>
+ * <br>
+ *
+ * @author fzwirn
+ */
+public class AdditionalTestConfig implements TestConfiguration {
+
+    static final String TEST_VALUE = "JUnitTest";
+
+    @Override
+    public Properties getProps() {
+        Properties props = new Properties();
+        props.put("jwtauth.issuer", AdditionalTestConfig.TEST_VALUE);
+        return props;
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [/] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
test feature


* **What is the current behavior?** (You can also link to an open issue here)
You have to use a RunnerConfiguration with a SpringDaemonTestRunner.RunnerConfig for Tests run with SpringDaemonTestRunner.


* **What is the new behavior (if this is a feature change)?**
By using @AdditionalRunnerConfiguration additional configurations (implementing TestConfiguration). 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
There are no breaking changes, as seen with AspectTest. 


* **Other information**:
* This allows for more detailed configurations in projects. A general RunnerConfiguration can be created. And then, for individual tests, additional configs can be added, as needed.