### PR TITLE
dvalin-jaxrs: Fix conflict between jetty ContextHandlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fixed vulnerabilities: CVE-2023-52428(nimbus-jose-jwt), CVE-2024-29857,CVE-2024-30171,CVE-2024-30172,CVE-2024-34447 (bouncycastle), CVE-2024-28752,CVE-2024-29736 (Apache CXF), CVE-2024-38808 (Spring Framework)
 * Corrected the use of @Nullable and @Nonnull annotations on created ivos and events, especially on the generated builders 
 * Add support for h2 embedded database
+* Fix conflicting jetty ContextHandlers for static files and web frontend
     
 # 1.35
 * Update dependencies

--- a/jaxrs/src/main/java/de/taimos/dvalin/jaxrs/JAXRSServerConfig.java
+++ b/jaxrs/src/main/java/de/taimos/dvalin/jaxrs/JAXRSServerConfig.java
@@ -103,7 +103,7 @@ public class JAXRSServerConfig {
     @Order(1)
     @Bean(name = "web-server-context-static")
     public ContextHandler staticContextHandler() throws IOException {
-        return createResourceContext("/", Resource.newResource("./static"));
+        return createResourceContext("/static", Resource.newResource("./static"));
     }
 
     @Order(2)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix jetty ContextHandlers for web and static files being in conflict since #136

* **What is the current behavior?** (You can also link to an open issue here)
Files located under "./static/" block access to the web frontend.

* **What is the new behavior (if this is a feature change)?**
Frontend is served under / and static files are served under /static/ which restores behavior before migration of jetty.xml in #136

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
Not if you do not rely on static files being served under "/". If that's the case adjust urls to static files.